### PR TITLE
How about turning on the Travis CI Cache feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 os: windows
 language: shell
 filter_secrets: false
-cache: false
+cache:
+   directories:
+   - $HOME/.gradle/caches/
+   - $HOME/.gradle/wrapper/
 before_install:
   - choco install openjdk -y
   - wget http://services.gradle.org/distributions/gradle-5.3-bin.zip


### PR DESCRIPTION
[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.
