### PR TITLE
Executes the builds much more quickly by Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - set TERM=dumb
   - gradle -version
 script:
-  - gradle clean install cleanTest test --exclude-task signArchives --no-daemon
+  - gradle clean install cleanTest test --exclude-task signArchives --daemon
 after_success:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
   - bash send.sh success $WEBHOOK_URL

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,7 +17,7 @@ git clone https://github.com/MSPaintIDE/NewOCR-javadocs .
 rm -rf *
 cd ../
 
-gradle javadoc --no-daemon
+gradle javadoc --daemon
 cd build/docs/
 mv javadoc/* ../../pages
 cd ../../pages


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
